### PR TITLE
Smarter data mapping conflict handling for selects

### DIFF
--- a/jdbc/src/main/kotlin/io/koalaql/jdbc/ResultSetRowSequence.kt
+++ b/jdbc/src/main/kotlin/io/koalaql/jdbc/ResultSetRowSequence.kt
@@ -23,7 +23,9 @@ class ResultSetRowSequence(
     private var alreadyIterated = false
     private var readCount = 0
 
-    private val columnMappings = columns.map { sharedMappings.deriveFor(it.type, localMappings) }
+    private val columnMappings = columns.map {
+        sharedMappings.deriveForReference(it, localMappings)
+    }
 
     override val row: RawResultRow get() = this
 

--- a/testing/src/test/kotlin/QueryTests.kt
+++ b/testing/src/test/kotlin/QueryTests.kt
@@ -1188,4 +1188,25 @@ abstract class QueryTests: ProvideTestDatabase {
         assertEquals(row[CustomDataLowercase.column].normalized, "abc")
         assertEquals(row[CustomDataUppercase.column].normalized, "abc")
     }
+
+    @Test
+    fun `labeled reference with custom type`() = withCxn(
+        CustomDataLowercase
+    ) { cxn ->
+        val data1 = CustomData("abc")
+
+        val label = label<CustomData>()
+
+        CustomDataLowercase
+            .insert(rowOf(CustomDataLowercase.column setTo data1))
+            .perform(cxn)
+
+        val (x, y) = CustomDataLowercase
+            .select(CustomDataLowercase.column, value(data1) as_ label)
+            .perform(cxn)
+            .single()
+
+        assertEquals(data1.normalized, x.normalized)
+        assertEquals(data1.normalized, y.normalized)
+    }
 }


### PR DESCRIPTION
This change introduces a better way of resolving conflicting custom type mappings in queries. Previously we've assumed that multiple mappings for the same type are equivalent and always use the first mapping in the scope of a query to bind the respective type. This causes issues when e.g. selecting from the join of two different tables that use different mappings for the same type.

Under the expanded strategy, we use the column reference to resolve the type mapping when possible. This allows us to resolve the correct type mapping when selecting columns. Conflicting custom type mappings will still cause problems when the type is used in expressions, inserts or non-columnar selects.