### PR TITLE
Table with defaults creation test

### DIFF
--- a/mysql/src/test/kotlin/MysqlCreateIfNotExistsTests.kt
+++ b/mysql/src/test/kotlin/MysqlCreateIfNotExistsTests.kt
@@ -29,4 +29,28 @@ class MysqlCreateIfNotExistsTests: CreateIfNotExistsTests(), MysqlTestProvider {
             appliedDdl.single().toAbridgedSql()
         )
     }
+
+    @Test
+    fun `table with mapped defaults`() {
+        val appliedDdl = AppliedDdlListener()
+
+        withDb(
+            declareBy = DeclareStrategy.CreateIfNotExists,
+            events = appliedDdl
+        ) { db ->
+            db.declareTables(ExampleTable)
+        }
+
+        assertEquals(
+            """
+                CREATE TABLE IF NOT EXISTS `Example`(
+                `id` INTEGER NOT NULL,
+                `asInt` INTEGER NOT NULL DEFAULT ?,
+                `asString` INTEGER NOT NULL DEFAULT ?,
+                CONSTRAINT `Example_id_pkey` PRIMARY KEY (`id`)
+                )
+            """.trimIndent(),
+            appliedDdl.single().toAbridgedSql()
+        )
+    }
 }

--- a/testing/src/test/kotlin/CreateIfNotExistsTests.kt
+++ b/testing/src/test/kotlin/CreateIfNotExistsTests.kt
@@ -16,4 +16,18 @@ abstract class CreateIfNotExistsTests: ProvideTestDatabase {
             index("reverseNameIndex", lastName, firstName)
         }
     }
+
+    enum class ExampleEnum {
+        CASE_A,
+        CASE_B
+    }
+
+    object ExampleTable : Table("Example") {
+        val id = column("id", INTEGER.primaryKey())
+
+        val asInt = column("asInt", INTEGER.mapToEnum<ExampleEnum> { it.ordinal }
+            .default(ExampleEnum.CASE_A))
+        val asString = column("asString", INTEGER.mapToEnum<ExampleEnum> { it.ordinal }
+            .default(ExampleEnum.CASE_B))
+    }
 }


### PR DESCRIPTION
* Adds a test for Mysql which creates a table with defaults
* Somewhat unbelievably, Postgres and pgjdbc do not support parameterized values in DDL forcing library authors to interpolate values into raw SQL. Supporting this safely will require some work.