### PR TITLE
Tokenized sql builder

### DIFF
--- a/core/src/main/kotlin/io/koalaql/ddl/MappedDataType.kt
+++ b/core/src/main/kotlin/io/koalaql/ddl/MappedDataType.kt
@@ -1,5 +1,6 @@
 package io.koalaql.ddl
 
+import io.koalaql.expr.Literal
 import kotlin.reflect.KClass
 
 class MappedDataType<F : Any, T : Any>(
@@ -7,6 +8,14 @@ class MappedDataType<F : Any, T : Any>(
     override val dataType: UnmappedDataType<F>,
     override val mapping: TypeMapping<F, T>
 ): DataType<F, T>() {
+    fun unconvertLiteral(from: Literal<T>) = Literal(
+        type = dataType.type,
+        value = from.value?.let { mapping.unconvert(it) }
+    )
+
+    @Suppress("unchecked_cast")
+    fun unconvertLiteralUnchecked(from: Literal<*>) = unconvertLiteral(from as Literal<T>)
+
     override fun <R : Any> map(mapping: TypeMapping<T, R>): DataType<F, R> =
         MappedDataType(mapping.type, dataType, this.mapping.then(mapping))
 }

--- a/core/src/main/kotlin/io/koalaql/sql/CompiledSqlBuilder.kt
+++ b/core/src/main/kotlin/io/koalaql/sql/CompiledSqlBuilder.kt
@@ -93,8 +93,13 @@ class CompiledSqlBuilder(
                     }
                 }
                 is LiteralToken -> {
+                    val value = token.value
+                    val mappedValue = mappings[value.type]
+                        ?.unconvertLiteralUnchecked(value)
+                        ?: value
+
                     contents.append("?")
-                    params.add(token.value)
+                    params.add(mappedValue)
                 }
                 is RawSqlToken -> {
                     contents.append(token.sql)

--- a/core/src/main/kotlin/io/koalaql/sql/CompiledSqlBuilder.kt
+++ b/core/src/main/kotlin/io/koalaql/sql/CompiledSqlBuilder.kt
@@ -10,7 +10,7 @@ import io.koalaql.sql.token.*
 import kotlin.reflect.KClass
 
 class CompiledSqlBuilder(
-    private val quoteStyle: IdentifierQuoteStyle
+    private val escapes: SqlEscapes
 ) {
     private val tokens = arrayListOf<SqlToken>()
 
@@ -86,11 +86,7 @@ class CompiledSqlBuilder(
                     is Unquoted -> {
                         contents.append(id.id)
                     }
-                    is Named -> {
-                        contents.append(quoteStyle.quote)
-                        contents.append(id.name)
-                        contents.append(quoteStyle.quote)
-                    }
+                    is Named -> escapes.identifier(contents, id)
                 }
                 is LiteralToken -> {
                     val value = token.value
@@ -98,8 +94,7 @@ class CompiledSqlBuilder(
                         ?.unconvertLiteralUnchecked(value)
                         ?: value
 
-                    contents.append("?")
-                    params.add(mappedValue)
+                    escapes.literal(contents, params, mappedValue)
                 }
                 is RawSqlToken -> {
                     contents.append(token.sql)

--- a/core/src/main/kotlin/io/koalaql/sql/IdentifierQuoteStyle.kt
+++ b/core/src/main/kotlin/io/koalaql/sql/IdentifierQuoteStyle.kt
@@ -1,8 +1,0 @@
-package io.koalaql.sql
-
-enum class IdentifierQuoteStyle(
-    val quote: String
-) {
-    BACKTICKS("`"),
-    DOUBLE("\"")
-}

--- a/core/src/main/kotlin/io/koalaql/sql/SqlEscapes.kt
+++ b/core/src/main/kotlin/io/koalaql/sql/SqlEscapes.kt
@@ -1,0 +1,14 @@
+package io.koalaql.sql
+
+import io.koalaql.expr.Literal
+import io.koalaql.identifier.Named
+
+interface SqlEscapes {
+    fun identifier(sql: StringBuilder, identifier: Named)
+
+    fun literal(
+        sql: StringBuilder,
+        params: MutableList<Literal<*>>,
+        literal: Literal<*>
+    )
+}

--- a/core/src/main/kotlin/io/koalaql/sql/token/BeginAbridgement.kt
+++ b/core/src/main/kotlin/io/koalaql/sql/token/BeginAbridgement.kt
@@ -1,0 +1,3 @@
+package io.koalaql.sql.token
+
+object BeginAbridgement: SqlToken

--- a/core/src/main/kotlin/io/koalaql/sql/token/EndAbridgement.kt
+++ b/core/src/main/kotlin/io/koalaql/sql/token/EndAbridgement.kt
@@ -1,0 +1,5 @@
+package io.koalaql.sql.token
+
+data class EndAbridgement(
+    val summary: String
+): SqlToken

--- a/core/src/main/kotlin/io/koalaql/sql/token/ErrorToken.kt
+++ b/core/src/main/kotlin/io/koalaql/sql/token/ErrorToken.kt
@@ -1,0 +1,5 @@
+package io.koalaql.sql.token
+
+data class ErrorToken(
+    val message: String
+): SqlToken

--- a/core/src/main/kotlin/io/koalaql/sql/token/IdentifierToken.kt
+++ b/core/src/main/kotlin/io/koalaql/sql/token/IdentifierToken.kt
@@ -1,0 +1,7 @@
+package io.koalaql.sql.token
+
+import io.koalaql.identifier.SqlIdentifier
+
+data class IdentifierToken(
+    val identifier: SqlIdentifier
+): SqlToken

--- a/core/src/main/kotlin/io/koalaql/sql/token/LiteralToken.kt
+++ b/core/src/main/kotlin/io/koalaql/sql/token/LiteralToken.kt
@@ -1,0 +1,7 @@
+package io.koalaql.sql.token
+
+import io.koalaql.expr.Literal
+
+data class LiteralToken(
+    val value: Literal<*>
+): SqlToken

--- a/core/src/main/kotlin/io/koalaql/sql/token/RawSqlToken.kt
+++ b/core/src/main/kotlin/io/koalaql/sql/token/RawSqlToken.kt
@@ -1,0 +1,5 @@
+package io.koalaql.sql.token
+
+data class RawSqlToken(
+    val sql: String
+): SqlToken

--- a/core/src/main/kotlin/io/koalaql/sql/token/SqlToken.kt
+++ b/core/src/main/kotlin/io/koalaql/sql/token/SqlToken.kt
@@ -1,0 +1,3 @@
+package io.koalaql.sql.token
+
+sealed interface SqlToken

--- a/h2/src/main/kotlin/io/koalaql/h2/H2Dialect.kt
+++ b/h2/src/main/kotlin/io/koalaql/h2/H2Dialect.kt
@@ -64,7 +64,7 @@ class H2Dialect(
         val results = mutableListOf<CompiledSql>()
 
         change.tables.created.forEach { (_, table) ->
-            val sql = CompiledSqlBuilder(IdentifierQuoteStyle.DOUBLE)
+            val sql = CompiledSqlBuilder(H2Escapes)
 
             ScopedSqlBuilder(
                 sql,
@@ -376,7 +376,7 @@ class H2Dialect(
 
     override fun compile(dml: BuiltDml): CompiledSql? {
         val sql = ScopedSqlBuilder(
-            CompiledSqlBuilder(IdentifierQuoteStyle.DOUBLE),
+            CompiledSqlBuilder(H2Escapes),
             Scope(NameRegistry { "C${it + 1}" }),
             compiler
         )

--- a/h2/src/main/kotlin/io/koalaql/h2/H2Escapes.kt
+++ b/h2/src/main/kotlin/io/koalaql/h2/H2Escapes.kt
@@ -1,0 +1,18 @@
+package io.koalaql.h2
+
+import io.koalaql.expr.Literal
+import io.koalaql.identifier.Named
+import io.koalaql.sql.SqlEscapes
+
+object H2Escapes: SqlEscapes {
+    override fun identifier(sql: StringBuilder, identifier: Named) {
+        sql.append("\"")
+        sql.append(identifier.name)
+        sql.append("\"")
+    }
+
+    override fun literal(sql: StringBuilder, params: MutableList<Literal<*>>, literal: Literal<*>) {
+        sql.append("?")
+        params.add(literal)
+    }
+}

--- a/jdbc/src/main/kotlin/io/koalaql/data/JdbcTypeMappings.kt
+++ b/jdbc/src/main/kotlin/io/koalaql/data/JdbcTypeMappings.kt
@@ -132,7 +132,7 @@ class JdbcTypeMappings {
     })
 
     @Suppress("unchecked_cast")
-    private fun <T : Any> mappingFor(type: KClass<T>): JdbcMappedType<T> =
+    fun <T : Any> mappingFor(type: KClass<T>): JdbcMappedType<T> =
         checkNotNull(mappings[type]) { "no JDBC mapping for $type" } as JdbcMappedType<T>
 
     @Suppress("unchecked_cast")

--- a/jdbc/src/main/kotlin/io/koalaql/jdbc/JdbcConnection.kt
+++ b/jdbc/src/main/kotlin/io/koalaql/jdbc/JdbcConnection.kt
@@ -11,6 +11,7 @@ import io.koalaql.expr.Column
 import io.koalaql.query.LabelListOf
 import io.koalaql.query.built.*
 import io.koalaql.sql.CompiledSql
+import io.koalaql.sql.TypeMappings
 import io.koalaql.values.RawResultRow
 import io.koalaql.values.RowSequence
 import io.koalaql.values.emptyRowSequence
@@ -34,7 +35,7 @@ class JdbcConnection(
 
         sql.parameters.forEachIndexed { ix, literal ->
             @Suppress("unchecked_cast")
-            val mapping = typeMappings.deriveFor(literal.type, sql.mappings) as JdbcMappedType<Any>
+            val mapping = typeMappings.mappingFor(literal.type) as JdbcMappedType<Any>
 
             literal.value
                 ?.let { mapping.writeJdbc(result, ix + 1, it) }

--- a/mysql/src/main/kotlin/io/koalaql/mysql/MysqlDialect.kt
+++ b/mysql/src/main/kotlin/io/koalaql/mysql/MysqlDialect.kt
@@ -131,7 +131,7 @@ class MysqlDialect: SqlDialect {
 
         return results.map {
             ScopedSqlBuilder(
-                CompiledSqlBuilder(IdentifierQuoteStyle.BACKTICKS),
+                CompiledSqlBuilder(MysqlEscapes),
                 Scope(NameRegistry { "column_$it" }),
                 compiler
             ).also(it).toSql()
@@ -510,7 +510,7 @@ class MysqlDialect: SqlDialect {
 
     override fun compile(dml: BuiltDml): CompiledSql? {
         val sql = ScopedSqlBuilder(
-            CompiledSqlBuilder(IdentifierQuoteStyle.BACKTICKS),
+            CompiledSqlBuilder(MysqlEscapes),
             Scope(NameRegistry { "column_$it" }),
             compiler
         )

--- a/mysql/src/main/kotlin/io/koalaql/mysql/MysqlEscapes.kt
+++ b/mysql/src/main/kotlin/io/koalaql/mysql/MysqlEscapes.kt
@@ -1,0 +1,18 @@
+package io.koalaql.mysql
+
+import io.koalaql.expr.Literal
+import io.koalaql.identifier.Named
+import io.koalaql.sql.SqlEscapes
+
+object MysqlEscapes: SqlEscapes {
+    override fun identifier(sql: StringBuilder, identifier: Named) {
+        sql.append("`")
+        sql.append(identifier.name)
+        sql.append("`")
+    }
+
+    override fun literal(sql: StringBuilder, params: MutableList<Literal<*>>, literal: Literal<*>) {
+        sql.append("?")
+        params.add(literal)
+    }
+}

--- a/mysql/src/test/kotlin/MysqlCreateIfNotExistsTests.kt
+++ b/mysql/src/test/kotlin/MysqlCreateIfNotExistsTests.kt
@@ -38,14 +38,15 @@ class MysqlCreateIfNotExistsTests: CreateIfNotExistsTests(), MysqlTestProvider {
             declareBy = DeclareStrategy.CreateIfNotExists,
             events = appliedDdl
         ) { db ->
-            db.declareTables(ExampleTable)
+            createAndCheckExample(db)
         }
 
         assertEquals(
             """
                 CREATE TABLE IF NOT EXISTS `Example`(
                 `id` INTEGER NOT NULL,
-                `asInt` INTEGER NOT NULL DEFAULT ?,
+                `asString` VARCHAR(100) NOT NULL DEFAULT ?,
+                `trickyDefault` VARCHAR(100) NOT NULL DEFAULT ?,
                 CONSTRAINT `Example_id_pkey` PRIMARY KEY (`id`)
                 )
             """.trimIndent(),

--- a/mysql/src/test/kotlin/MysqlCreateIfNotExistsTests.kt
+++ b/mysql/src/test/kotlin/MysqlCreateIfNotExistsTests.kt
@@ -46,7 +46,6 @@ class MysqlCreateIfNotExistsTests: CreateIfNotExistsTests(), MysqlTestProvider {
                 CREATE TABLE IF NOT EXISTS `Example`(
                 `id` INTEGER NOT NULL,
                 `asInt` INTEGER NOT NULL DEFAULT ?,
-                `asString` INTEGER NOT NULL DEFAULT ?,
                 CONSTRAINT `Example_id_pkey` PRIMARY KEY (`id`)
                 )
             """.trimIndent(),

--- a/postgres/build.gradle.kts
+++ b/postgres/build.gradle.kts
@@ -4,8 +4,7 @@ plugins {
 
 dependencies {
     implementation(project(":jdbc"))
-
-    testImplementation("org.postgresql:postgresql:42.2.23")
+    api("org.postgresql:postgresql:42.5.1")
 
     testImplementation(project(":testing"))
     testImplementation(project(":testing", "testArchive"))

--- a/postgres/src/main/kotlin/io/koalaql/postgres/PostgresDialect.kt
+++ b/postgres/src/main/kotlin/io/koalaql/postgres/PostgresDialect.kt
@@ -188,7 +188,7 @@ class PostgresDialect: SqlDialect {
         val results = mutableListOf<CompiledSql>()
 
         change.tables.created.forEach { (_, table) ->
-            val sql = CompiledSqlBuilder(IdentifierQuoteStyle.DOUBLE)
+            val sql = CompiledSqlBuilder(PostgresDdlEscapes)
 
             ScopedSqlBuilder(
                 sql,
@@ -202,7 +202,7 @@ class PostgresDialect: SqlDialect {
         change.tables.created.forEach { (_, table) ->
             table.indexes.forEach { index ->
                 if (index.def.type == IndexType.INDEX) {
-                    val sql = CompiledSqlBuilder(IdentifierQuoteStyle.DOUBLE)
+                    val sql = CompiledSqlBuilder(PostgresDdlEscapes)
 
                     ScopedSqlBuilder(
                         sql,
@@ -447,7 +447,7 @@ class PostgresDialect: SqlDialect {
 
     override fun compile(dml: BuiltDml): CompiledSql? {
         val sql = ScopedSqlBuilder(
-            CompiledSqlBuilder(IdentifierQuoteStyle.DOUBLE),
+            CompiledSqlBuilder(PostgresDmlEscapes),
             Scope(NameRegistry { "column${it + 1}" }),
             compiler
         )

--- a/postgres/src/main/kotlin/io/koalaql/postgres/SqlEscapes.kt
+++ b/postgres/src/main/kotlin/io/koalaql/postgres/SqlEscapes.kt
@@ -3,24 +3,34 @@ package io.koalaql.postgres
 import io.koalaql.expr.Literal
 import io.koalaql.identifier.Named
 import io.koalaql.sql.SqlEscapes
+import org.postgresql.core.Utils
 
 object PostgresDdlEscapes: SqlEscapes {
     override fun identifier(sql: StringBuilder, identifier: Named) {
-        sql.append("\"")
-        sql.append(identifier.name)
-        sql.append("\"")
+        Utils.escapeIdentifier(sql, identifier.name)
     }
 
     override fun literal(sql: StringBuilder, params: MutableList<Literal<*>>, literal: Literal<*>) {
-        error("not supported")
+        when (literal.type) {
+            Byte::class -> sql.append("${literal.value as Byte}")
+            Short::class -> sql.append("${literal.value as Short}")
+            Int::class -> sql.append("${literal.value as Int}")
+            Long::class -> sql.append("${literal.value as Long}")
+            Float::class -> sql.append("${literal.value as Float}")
+            Double::class -> sql.append("${literal.value as Double}")
+            String::class -> {
+                sql.append("'")
+                Utils.escapeLiteral(sql, literal.value as String, true)
+                sql.append("'")
+            }
+            else -> error("${literal.type.simpleName} literals are not supported in Postgres DDL")
+        }
     }
 }
 
 object PostgresDmlEscapes: SqlEscapes {
     override fun identifier(sql: StringBuilder, identifier: Named) {
-        sql.append("\"")
-        sql.append(identifier.name)
-        sql.append("\"")
+        Utils.escapeIdentifier(sql, identifier.name)
     }
 
     override fun literal(sql: StringBuilder, params: MutableList<Literal<*>>, literal: Literal<*>) {

--- a/postgres/src/main/kotlin/io/koalaql/postgres/SqlEscapes.kt
+++ b/postgres/src/main/kotlin/io/koalaql/postgres/SqlEscapes.kt
@@ -1,0 +1,30 @@
+package io.koalaql.postgres
+
+import io.koalaql.expr.Literal
+import io.koalaql.identifier.Named
+import io.koalaql.sql.SqlEscapes
+
+object PostgresDdlEscapes: SqlEscapes {
+    override fun identifier(sql: StringBuilder, identifier: Named) {
+        sql.append("\"")
+        sql.append(identifier.name)
+        sql.append("\"")
+    }
+
+    override fun literal(sql: StringBuilder, params: MutableList<Literal<*>>, literal: Literal<*>) {
+        error("not supported")
+    }
+}
+
+object PostgresDmlEscapes: SqlEscapes {
+    override fun identifier(sql: StringBuilder, identifier: Named) {
+        sql.append("\"")
+        sql.append(identifier.name)
+        sql.append("\"")
+    }
+
+    override fun literal(sql: StringBuilder, params: MutableList<Literal<*>>, literal: Literal<*>) {
+        sql.append("?")
+        params.add(literal)
+    }
+}

--- a/postgres/src/test/kotlin/PostgresCreateIfNotExistsTests.kt
+++ b/postgres/src/test/kotlin/PostgresCreateIfNotExistsTests.kt
@@ -1,7 +1,7 @@
 import io.koalaql.DeclareStrategy
 import io.koalaql.test.AppliedDdlListener
-import kotlin.test.assertEquals
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class PostgresCreateIfNotExistsTests: CreateIfNotExistsTests(),  PostgresTestProvider {
     @Test
@@ -33,6 +33,30 @@ class PostgresCreateIfNotExistsTests: CreateIfNotExistsTests(),  PostgresTestPro
                 CREATE INDEX IF NOT EXISTS "reverseNameIndex" ON "Customer" ("lastName", "firstName")
             """.trimIndent(),
             appliedDdl[1].toAbridgedSql()
+        )
+    }
+
+    @Test
+    fun `table with mapped defaults`() {
+        val appliedDdl = AppliedDdlListener()
+
+        withDb(
+            declareBy = DeclareStrategy.CreateIfNotExists,
+            events = appliedDdl
+        ) { db ->
+            createAndCheckExample(db)
+        }
+
+        assertEquals(
+            """
+                CREATE TABLE IF NOT EXISTS "Example"(
+                "id" INTEGER NOT NULL,
+                "asString" VARCHAR(100) NOT NULL DEFAULT 'CASE_B',
+                "trickyDefault" VARCHAR(100) NOT NULL DEFAULT '''"\$`''"$',
+                CONSTRAINT "Example_id_pkey" PRIMARY KEY ("id")
+                )
+            """.trimIndent(),
+            appliedDdl.single().toAbridgedSql()
         )
     }
 }

--- a/testing/src/test/kotlin/CreateIfNotExistsTests.kt
+++ b/testing/src/test/kotlin/CreateIfNotExistsTests.kt
@@ -27,7 +27,5 @@ abstract class CreateIfNotExistsTests: ProvideTestDatabase {
 
         val asInt = column("asInt", INTEGER.mapToEnum<ExampleEnum> { it.ordinal }
             .default(ExampleEnum.CASE_A))
-        val asString = column("asString", INTEGER.mapToEnum<ExampleEnum> { it.ordinal }
-            .default(ExampleEnum.CASE_B))
     }
 }

--- a/testing/src/test/kotlin/CreateIfNotExistsTests.kt
+++ b/testing/src/test/kotlin/CreateIfNotExistsTests.kt
@@ -1,7 +1,12 @@
+import io.koalaql.DataSource
 import io.koalaql.ddl.INTEGER
 import io.koalaql.ddl.Table
 import io.koalaql.ddl.VARCHAR
 import io.koalaql.dsl.keys
+import io.koalaql.dsl.rowOf
+import io.koalaql.dsl.setTo
+import io.koalaql.dsl.values
+import kotlin.test.assertEquals
 
 abstract class CreateIfNotExistsTests: ProvideTestDatabase {
     object CustomerTable : Table("Customer") {
@@ -25,7 +30,23 @@ abstract class CreateIfNotExistsTests: ProvideTestDatabase {
     object ExampleTable : Table("Example") {
         val id = column("id", INTEGER.primaryKey())
 
-        val asInt = column("asInt", INTEGER.mapToEnum<ExampleEnum> { it.ordinal }
-            .default(ExampleEnum.CASE_A))
+        val asString = column("asString", VARCHAR(100).mapToEnum<ExampleEnum> { it.name }
+            .default(ExampleEnum.CASE_B))
+
+        val trickyDefault = column("trickyDefault", VARCHAR(100).default("""'"\$`'"$"""))
+    }
+
+    fun createAndCheckExample(db: DataSource) {
+        db.declareTables(ExampleTable)
+
+        ExampleTable
+            .insert(values(rowOf(ExampleTable.id setTo 1)))
+            .perform(db)
+
+        val default = ExampleTable
+            .perform(db)
+            .single()[ExampleTable.trickyDefault]
+
+        assertEquals("""'"\$`'"$""", default)
     }
 }


### PR DESCRIPTION
koala-postgres module:
* Now includes pgjdbc as an api dependency
* Now supports literals (e.g. for DEFAULT) in generated DDL
* Uses pgjdbc Utils to escape identifiers and literals in generated SQL

Re-architected SQL building phase to support the need to manually escape literals for Postgres DDL
* Mapped type literals in generated SQL are now resolved to their underlying types during string building
* String building is now deferred to the end of the building process so that type mappings may be fully collected