### PR TITLE
Generic Type Support

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -4,5 +4,4 @@ plugins {
 
 dependencies {
     api(kotlin("stdlib"))
-    api(kotlin("reflect"))
 }

--- a/core/src/main/kotlin/io/koalaql/ddl/DataType.kt
+++ b/core/src/main/kotlin/io/koalaql/ddl/DataType.kt
@@ -1,33 +1,36 @@
 package io.koalaql.ddl
 
 import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 sealed class DataType<F : Any, T : Any> {
-    abstract val type: KClass<T>
+    abstract val type: KType
     abstract val dataType: UnmappedDataType<F>
 
     abstract val mapping: TypeMapping<F, T>?
 
     abstract fun <R : Any> map(mapping: TypeMapping<T, R>): DataType<F, R>
 
-    fun <R : Any> map(type: KClass<R>, to: (T) -> R, from: (R) -> T): DataType<F, R> = map(object : TypeMapping<T, R> {
-        override val type: KClass<R> = type
+    fun <R : Any> map(type: KType, to: (T) -> R, from: (R) -> T): DataType<F, R> = map(object : TypeMapping<T, R> {
+        override val type: KType = type
         override fun convert(value: T): R = to(value)
         override fun unconvert(value: R): T = from(value)
     })
 
     inline fun <reified R : Any> map(noinline to: (T) -> R, noinline from: (R) -> T): DataType<F, R> =
-        map(R::class, to, from)
+        map(typeOf<R>(), to, from)
 
     fun <E : Enum<E>> mapToEnum(
-        type: KClass<E>,
+        type: KType,
         keySelector: (E) -> T
     ): DataType<F, E> {
-        val enumByKey = type.java.enumConstants
+        @Suppress("unchecked_cast")
+        val enumByKey = (type.classifier as KClass<E>).java.enumConstants
             .associateBy(keySelector)
 
         return map(object : TypeMapping<T, E> {
-            override val type: KClass<E> = type
+            override val type: KType = type
             override fun convert(value: T): E = enumByKey.getValue(value)
             override fun unconvert(value: E): T = keySelector(value)
         })
@@ -35,5 +38,5 @@ sealed class DataType<F : Any, T : Any> {
 
     inline fun <reified E : Enum<E>> mapToEnum(
         noinline keySelector: (E) -> T
-    ) = mapToEnum(E::class, keySelector)
+    ) = mapToEnum(typeOf<E>(), keySelector)
 }

--- a/core/src/main/kotlin/io/koalaql/ddl/MappedDataType.kt
+++ b/core/src/main/kotlin/io/koalaql/ddl/MappedDataType.kt
@@ -1,10 +1,10 @@
 package io.koalaql.ddl
 
 import io.koalaql.expr.Literal
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 class MappedDataType<F : Any, T : Any>(
-    override val type: KClass<T>,
+    override val type: KType,
     override val dataType: UnmappedDataType<F>,
     override val mapping: TypeMapping<F, T>
 ): DataType<F, T>() {

--- a/core/src/main/kotlin/io/koalaql/ddl/Table.kt
+++ b/core/src/main/kotlin/io/koalaql/ddl/Table.kt
@@ -11,7 +11,6 @@ import io.koalaql.expr.Expr
 import io.koalaql.query.Alias
 import io.koalaql.query.TableRelation
 import io.koalaql.query.built.BuiltRelation
-import kotlin.reflect.jvm.jvmName
 
 abstract class Table protected constructor(
     override val tableName: TableName
@@ -40,7 +39,7 @@ abstract class Table protected constructor(
     private val usedNames: HashSet<String> = hashSetOf()
 
     private fun takeName(name: String) {
-        check(usedNames.add(name)) { "${this::class.jvmName}: field name \"$name\" is already in use" }
+        check(usedNames.add(name)) { "${javaClass.name}: field name \"$name\" is already in use" }
     }
 
     private fun registerColumn(column: TableColumn<*>) {
@@ -94,7 +93,7 @@ abstract class Table protected constructor(
         .map {
             when (it) {
                 is Column -> it.symbol
-                else -> error("${this::class.jvmName}: key component $it can not be named")
+                else -> error("${javaClass.name}: key component $it can not be named")
             }
         }
         .joinToString("_")
@@ -104,7 +103,7 @@ abstract class Table protected constructor(
 
     protected fun primaryKey(name: String, keys: KeyList): BuiltNamedIndex {
         check(primaryKey == null) {
-            "${this::class.jvmName}: could not create the primary key $name because there is already a primary key ${primaryKey?.name}"
+            "${javaClass.name}: could not create the primary key $name because there is already a primary key ${primaryKey?.name}"
         }
 
         takeName(name)

--- a/core/src/main/kotlin/io/koalaql/ddl/TableColumn.kt
+++ b/core/src/main/kotlin/io/koalaql/ddl/TableColumn.kt
@@ -3,13 +3,12 @@ package io.koalaql.ddl
 import io.koalaql.ddl.built.BuiltColumnDef
 import io.koalaql.expr.Column
 import io.koalaql.identifier.Unnamed
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
-@Suppress("unchecked_cast")
 open class TableColumn<T : Any>(
     val table: Table,
     symbol: String,
     val builtDef: BuiltColumnDef
-): Column<T>(symbol, builtDef.columnType.type as KClass<T>, Unnamed()) {
+): Column<T>(symbol, builtDef.columnType.type, Unnamed()) {
     override fun toString(): String = "${table.tableName}.$symbol"
 }

--- a/core/src/main/kotlin/io/koalaql/ddl/TypeMapping.kt
+++ b/core/src/main/kotlin/io/koalaql/ddl/TypeMapping.kt
@@ -1,15 +1,15 @@
 package io.koalaql.ddl
 
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 interface TypeMapping<F, T : Any> {
-    val type: KClass<T>
+    val type: KType
 
     fun convert(value: F): T
     fun unconvert(value: T): F
 
     fun <R : Any> then(next: TypeMapping<T, R>): TypeMapping<F, R> = object : TypeMapping<F, R> {
-        override val type: KClass<R> = next.type
+        override val type: KType = next.type
 
         override fun convert(value: F): R = next.convert(this@TypeMapping.convert(value))
         override fun unconvert(value: R): F = this@TypeMapping.unconvert(next.unconvert(value))

--- a/core/src/main/kotlin/io/koalaql/ddl/UnmappedDataType.kt
+++ b/core/src/main/kotlin/io/koalaql/ddl/UnmappedDataType.kt
@@ -6,10 +6,11 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 sealed class UnmappedDataType<T : Any>(
-    override val type: KClass<T>
+    override val type: KType
 ): DataType<T, T>() {
     override val mapping: TypeMapping<T, T>? get() = null
 
@@ -58,36 +59,36 @@ sealed class UnmappedDataType<T : Any>(
 }
 
 sealed class PrimitiveDataType<T : Any>(
-    type: KClass<T>
+    type: KType
 ): UnmappedDataType<T>(type) {
     override fun equals(other: Any?): Boolean = this === other
     override fun hashCode(): Int = System.identityHashCode(this)
 }
 
-object FLOAT : PrimitiveDataType<Float>(Float::class)
-object DOUBLE : PrimitiveDataType<Double>(Double::class)
+object FLOAT : PrimitiveDataType<Float>(typeOf<Float>())
+object DOUBLE : PrimitiveDataType<Double>(typeOf<Double>())
 
-object TINYINT: PrimitiveDataType<Byte>(Byte::class) {
-    object UNSIGNED: PrimitiveDataType<UByte>(UByte::class)
+object TINYINT: PrimitiveDataType<Byte>(typeOf<Byte>()) {
+    object UNSIGNED: PrimitiveDataType<UByte>(typeOf<UByte>())
 }
 
-object SMALLINT: PrimitiveDataType<Short>(Short::class) {
-    object UNSIGNED: PrimitiveDataType<UShort>(UShort::class)
+object SMALLINT: PrimitiveDataType<Short>(typeOf<Short>()) {
+    object UNSIGNED: PrimitiveDataType<UShort>(typeOf<UShort>())
 }
 
-object INTEGER: PrimitiveDataType<Int>(Int::class) {
-    object UNSIGNED: PrimitiveDataType<UInt>(UInt::class)
+object INTEGER: PrimitiveDataType<Int>(typeOf<Int>()) {
+    object UNSIGNED: PrimitiveDataType<UInt>(typeOf<UInt>())
 }
 
-object BIGINT: PrimitiveDataType<Long>(Long::class) {
-    object UNSIGNED: PrimitiveDataType<ULong>(ULong::class)
+object BIGINT: PrimitiveDataType<Long>(typeOf<Long>()) {
+    object UNSIGNED: PrimitiveDataType<ULong>(typeOf<ULong>())
 }
 
-object DATE: PrimitiveDataType<LocalDate>(LocalDate::class)
+object DATE: PrimitiveDataType<LocalDate>(typeOf<LocalDate>())
 
 open class TIMESTAMP(
     val precision: Int? = null
-): UnmappedDataType<Instant>(Instant::class) {
+): UnmappedDataType<Instant>(typeOf<Instant>()) {
     companion object : TIMESTAMP()
 
     override fun equals(other: Any?): Boolean =
@@ -96,12 +97,12 @@ open class TIMESTAMP(
     override fun hashCode(): Int = precision.hashCode()
 }
 
-object TEXT: PrimitiveDataType<String>(String::class)
-object BOOLEAN: PrimitiveDataType<Boolean>(Boolean::class)
+object TEXT: PrimitiveDataType<String>(typeOf<String>())
+object BOOLEAN: PrimitiveDataType<Boolean>(typeOf<Boolean>())
 
 open class TIME(
     val precision: Int? = null
-): UnmappedDataType<LocalTime>(LocalTime::class) {
+): UnmappedDataType<LocalTime>(typeOf<LocalTime>()) {
     companion object : TIME()
 
     override fun equals(other: Any?): Boolean =
@@ -112,7 +113,7 @@ open class TIME(
 
 open class DATETIME(
     val precision: Int? = null
-): UnmappedDataType<LocalDateTime>(LocalDateTime::class) {
+): UnmappedDataType<LocalDateTime>(typeOf<LocalDateTime>()) {
     companion object : DATETIME()
 
     override fun equals(other: Any?): Boolean =
@@ -123,7 +124,7 @@ open class DATETIME(
 
 class VARCHAR(
     val maxLength: Int
-): UnmappedDataType<String>(String::class) {
+): UnmappedDataType<String>(typeOf<String>()) {
     override fun equals(other: Any?): Boolean = other is VARCHAR && maxLength == other.maxLength
     override fun hashCode(): Int = maxLength.hashCode()
 
@@ -132,7 +133,7 @@ class VARCHAR(
 
 class VARBINARY(
     val maxLength: Int
-): UnmappedDataType<ByteArray>(ByteArray::class) {
+): UnmappedDataType<ByteArray>(typeOf<ByteArray>()) {
     override fun equals(other: Any?): Boolean = other is VARBINARY && maxLength == other.maxLength
     override fun hashCode(): Int = maxLength.hashCode()
 }
@@ -141,7 +142,7 @@ class DECIMAL(
     val precision: Int,
     val scale: Int
 ): UnmappedDataType<BigDecimal>(
-    BigDecimal::class
+    typeOf<BigDecimal>()
 ) {
     override fun equals(other: Any?): Boolean = other is DECIMAL
         && precision == other.precision
@@ -151,11 +152,11 @@ class DECIMAL(
 }
 
 class RAW<T : Any>(
-    type: KClass<T>,
+    type: KType,
     override val sql: String,
 ): UnmappedDataType<T>(type), StandardSql {
     companion object {
-        inline operator fun <reified T : Any> invoke(sql: String) = RAW(T::class, sql)
+        inline operator fun <reified T : Any> invoke(sql: String) = RAW<T>(typeOf<T>(), sql)
     }
 
     override fun equals(other: Any?): Boolean = other is RAW<*>
@@ -165,4 +166,4 @@ class RAW<T : Any>(
     override fun hashCode(): Int = sql.hashCode()
 }
 
-object JSON: PrimitiveDataType<JsonData>(JsonData::class)
+object JSON: PrimitiveDataType<JsonData>(typeOf<JsonData>())

--- a/core/src/main/kotlin/io/koalaql/dsl/Exprs.kt
+++ b/core/src/main/kotlin/io/koalaql/dsl/Exprs.kt
@@ -8,6 +8,7 @@ import io.koalaql.expr.*
 import io.koalaql.query.Subqueryable
 import io.koalaql.query.built.BuilderContext
 import io.koalaql.sql.RawSqlBuilder
+import kotlin.reflect.typeOf
 
 infix fun <T : Any> Expr<T>.as_(reference: Reference<T>): SelectedExpr<T> =
     SelectedExpr(this, reference)
@@ -83,7 +84,7 @@ fun <T : Any> cast(from: Expr<*>, to: UnmappedDataType<T>): Expr<T> =
     CastExpr(from, to)
 
 inline fun <reified T : Any> value(value: T?): Literal<T> =
-    Literal(T::class, value)
+    Literal(typeOf<T>(), value)
 
 fun <T : Any> all(subquery: ExprQueryable<T>): ComparisonOperand<T> =
     ComparedQuery(ComparedQueryType.ALL, with (subquery) { BuilderContext.buildQuery() })

--- a/core/src/main/kotlin/io/koalaql/dsl/Names.kt
+++ b/core/src/main/kotlin/io/koalaql/dsl/Names.kt
@@ -2,6 +2,7 @@ package io.koalaql.dsl
 
 import io.koalaql.expr.Label
 import io.koalaql.identifier.LabelIdentifier
+import kotlin.reflect.typeOf
 
 inline fun <reified T : Any> label(identifier: String? = null): Label<T> =
-    Label(T::class, LabelIdentifier(identifier))
+    Label(typeOf<T>(), LabelIdentifier(identifier))

--- a/core/src/main/kotlin/io/koalaql/expr/Column.kt
+++ b/core/src/main/kotlin/io/koalaql/expr/Column.kt
@@ -1,11 +1,11 @@
 package io.koalaql.expr
 
 import io.koalaql.identifier.LabelIdentifier
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 abstract class Column<T : Any>(
     val symbol: String,
-    override val type: KClass<T>,
+    override val type: KType,
     override val identifier: LabelIdentifier
 ): NamedReference<T>(
     type,

--- a/core/src/main/kotlin/io/koalaql/expr/Label.kt
+++ b/core/src/main/kotlin/io/koalaql/expr/Label.kt
@@ -1,13 +1,13 @@
 package io.koalaql.expr
 
 import io.koalaql.identifier.LabelIdentifier
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 class Label<T : Any>(
-    type: KClass<T>,
+    type: KType,
     identifier: LabelIdentifier
 ): NamedReference<T>(type, identifier) {
     override fun toString(): String {
-        return "label_of_${type.simpleName?.lowercase()}($identifier)"
+        return "label of `$identifier`, $type"
     }
 }

--- a/core/src/main/kotlin/io/koalaql/expr/Literal.kt
+++ b/core/src/main/kotlin/io/koalaql/expr/Literal.kt
@@ -1,10 +1,10 @@
 package io.koalaql.expr
 
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 class Literal<T : Any>(
-    val type: KClass<T>,
+    val type: KType,
     val value: T?
 ): Expr<T> {
-    override fun toString(): String = "${type.simpleName}($value)"
+    override fun toString(): String = "($value): $type"
 }

--- a/core/src/main/kotlin/io/koalaql/expr/Reference.kt
+++ b/core/src/main/kotlin/io/koalaql/expr/Reference.kt
@@ -2,10 +2,10 @@ package io.koalaql.expr
 
 import io.koalaql.identifier.LabelIdentifier
 import io.koalaql.query.Alias
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 sealed interface Reference<T : Any>: SelectOperand<T> {
-    val type: KClass<T>
+    val type: KType
 
     val identifier: LabelIdentifier?
 
@@ -20,7 +20,7 @@ sealed interface Reference<T : Any>: SelectOperand<T> {
 }
 
 class AliasedReference<T : Any>(
-    override val type: KClass<T>,
+    override val type: KType,
     private val alias: Alias,
     private val reference: Reference<T>
 ): Reference<T> {
@@ -38,7 +38,7 @@ class AliasedReference<T : Any>(
 }
 
 abstract class NamedReference<T : Any>(
-    override val type: KClass<T>,
+    override val type: KType,
     override val identifier: LabelIdentifier
 ): Reference<T> {
     override fun equals(other: Any?): Boolean =

--- a/core/src/main/kotlin/io/koalaql/sql/CompiledSqlBuilder.kt
+++ b/core/src/main/kotlin/io/koalaql/sql/CompiledSqlBuilder.kt
@@ -7,14 +7,14 @@ import io.koalaql.identifier.Named
 import io.koalaql.identifier.SqlIdentifier
 import io.koalaql.identifier.Unquoted
 import io.koalaql.sql.token.*
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 class CompiledSqlBuilder(
     private val escapes: SqlEscapes
 ) {
     private val tokens = arrayListOf<SqlToken>()
 
-    private val mappings = hashMapOf<KClass<*>, MappedDataType<*, *>>()
+    private val mappings = hashMapOf<KType, MappedDataType<*, *>>()
 
     fun beginAbridgement() {
         tokens.add(BeginAbridgement)

--- a/core/src/main/kotlin/io/koalaql/sql/TypeMappings.kt
+++ b/core/src/main/kotlin/io/koalaql/sql/TypeMappings.kt
@@ -1,12 +1,12 @@
 package io.koalaql.sql
 
 import io.koalaql.ddl.MappedDataType
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 class TypeMappings(
-    private val mappings: Map<KClass<*>, MappedDataType<*, *>>
+    private val mappings: Map<KType, MappedDataType<*, *>>
 ) {
     @Suppress("unchecked_cast")
-    operator fun <T : Any> get(type: KClass<T>): MappedDataType<*, T>? =
+    operator fun <T : Any> get(type: KType): MappedDataType<*, T>? =
         mappings[type] as? MappedDataType<*, T>
 }

--- a/core/src/test/kotlin/io/koalaql/TableTests.kt
+++ b/core/src/test/kotlin/io/koalaql/TableTests.kt
@@ -1,7 +1,6 @@
 package io.koalaql
 
 import io.koalaql.ddl.Table
-import io.koalaql.ddl.Table.Companion.primaryKey
 import io.koalaql.ddl.VARCHAR
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/docs/src/main/kotlin/io/koalaql/docs/ExampleData.kt
+++ b/docs/src/main/kotlin/io/koalaql/docs/ExampleData.kt
@@ -2,7 +2,10 @@ package io.koalaql.docs
 
 import io.koalaql.DataSource
 import io.koalaql.sql.CompiledSql
+import java.math.BigDecimal
+import java.math.BigInteger
 import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.typeOf
 
 class ExampleData(
     val db: DataSource,
@@ -28,13 +31,16 @@ class ExampleData(
                 val type = param.type
                 val value = param.value
 
-                when {
-                    type.isSubclassOf(Number::class) -> {
-                        "$value"
-                    }
-                    type.isSubclassOf(CharSequence::class) -> {
-                        "'${value.toString().replace("'", "\\'")}'"
-                    }
+                when (type) {
+                    typeOf<Byte>(),
+                    typeOf<Short>(),
+                    typeOf<Int>(),
+                    typeOf<Long>(),
+                    typeOf<Float>(),
+                    typeOf<Double>(),
+                    typeOf<BigInteger>(),
+                    typeOf<BigDecimal>() -> "$value"
+                    typeOf<String>() -> "'${value.toString().replace("'", "\\'")}'"
                     else -> error("can't unparameterize $this")
                 }
             }

--- a/h2/src/main/kotlin/io/koalaql/h2/H2Dialect.kt
+++ b/h2/src/main/kotlin/io/koalaql/h2/H2Dialect.kt
@@ -15,6 +15,7 @@ import io.koalaql.sql.*
 import io.koalaql.window.*
 import io.koalaql.window.built.BuiltWindow
 import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 class H2Dialect(
     private val compatibilityMode: H2CompatibilityMode? = null
@@ -23,7 +24,7 @@ class H2Dialect(
         override fun addLiteral(builder: ScopedSqlBuilder, value: Literal<*>?) {
             builder.output.addLiteral(value)
 
-            if (value?.type == JsonData::class && value.value != null) {
+            if (value?.type == typeOf<JsonData>() && value.value != null) {
                 builder.output.addSql(" FORMAT JSON")
             }
         }

--- a/h2/src/main/kotlin/io/koalaql/h2/H2Dialect.kt
+++ b/h2/src/main/kotlin/io/koalaql/h2/H2Dialect.kt
@@ -14,7 +14,7 @@ import io.koalaql.query.built.*
 import io.koalaql.sql.*
 import io.koalaql.window.*
 import io.koalaql.window.built.BuiltWindow
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 class H2Dialect(
     private val compatibilityMode: H2CompatibilityMode? = null
@@ -109,7 +109,7 @@ class H2Dialect(
             val finalExpr = when (default) {
                 is ColumnDefaultExpr -> default.expr
                 is ColumnDefaultValue -> Literal(
-                    def.columnType.type as KClass<Any>,
+                    def.columnType.type,
                     default.value
                 )
             }

--- a/h2/src/main/kotlin/io/koalaql/h2/H2TypeMappings.kt
+++ b/h2/src/main/kotlin/io/koalaql/h2/H2TypeMappings.kt
@@ -10,6 +10,7 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE
 import java.time.format.DateTimeFormatter.ISO_LOCAL_TIME
 import java.time.format.DateTimeFormatterBuilder
+import kotlin.reflect.typeOf
 
 fun H2TypeMappings(): JdbcTypeMappings {
     val result = JdbcTypeMappings()
@@ -22,7 +23,7 @@ fun H2TypeMappings(): JdbcTypeMappings {
         .appendOffset("+HH:mm", "")
         .toFormatter()
 
-    result.register(JsonData::class, object : JdbcMappedType<JsonData> {
+    result.register(typeOf<JsonData>(), object : JdbcMappedType<JsonData> {
         override fun writeJdbc(stmt: PreparedStatement, index: Int, value: JsonData) {
             stmt.setBytes(index, value.asString.toByteArray())
         }
@@ -31,7 +32,7 @@ fun H2TypeMappings(): JdbcTypeMappings {
             rs.getBytes(index)?.let { JsonData(it.toString(Charsets.UTF_8)) }
     })
 
-    result.register(Instant::class, object : JdbcMappedType<Instant> {
+    result.register(typeOf<Instant>(), object : JdbcMappedType<Instant> {
         override fun writeJdbc(stmt: PreparedStatement, index: Int, value: Instant) {
             stmt.setObject(index, value)
         }

--- a/jdbc/src/main/kotlin/io/koalaql/jdbc/JdbcConnection.kt
+++ b/jdbc/src/main/kotlin/io/koalaql/jdbc/JdbcConnection.kt
@@ -35,7 +35,7 @@ class JdbcConnection(
 
         sql.parameters.forEachIndexed { ix, literal ->
             @Suppress("unchecked_cast")
-            val mapping = typeMappings.mappingFor(literal.type) as JdbcMappedType<Any>
+            val mapping = typeMappings.mappingFor<Any>(literal.type)
 
             literal.value
                 ?.let { mapping.writeJdbc(result, ix + 1, it) }

--- a/mysql/src/main/kotlin/io/koalaql/mysql/MysqlDialect.kt
+++ b/mysql/src/main/kotlin/io/koalaql/mysql/MysqlDialect.kt
@@ -15,7 +15,7 @@ import io.koalaql.query.built.*
 import io.koalaql.sql.*
 import io.koalaql.window.LabeledWindow
 import io.koalaql.window.built.BuiltWindow
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 class MysqlDialect: SqlDialect {
     private val compiler = object : Compiler {
@@ -187,7 +187,7 @@ class MysqlDialect: SqlDialect {
             val finalExpr = when (default) {
                 is ColumnDefaultExpr -> default.expr
                 is ColumnDefaultValue -> Literal(
-                    def.columnType.type as KClass<Any>,
+                    def.columnType.type,
                     default.value
                 )
             }

--- a/mysql/src/main/kotlin/io/koalaql/mysql/MysqlTypeMappings.kt
+++ b/mysql/src/main/kotlin/io/koalaql/mysql/MysqlTypeMappings.kt
@@ -8,11 +8,12 @@ import java.sql.ResultSet
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
+import kotlin.reflect.typeOf
 
 fun MysqlTypeMappings(): JdbcTypeMappings {
     val result = JdbcTypeMappings()
 
-    result.register(Instant::class, object : JdbcMappedType<Instant> {
+    result.register(typeOf<Instant>(), object : JdbcMappedType<Instant> {
         override fun writeJdbc(stmt: PreparedStatement, index: Int, value: Instant) {
             stmt.setObject(index, value.atOffset(ZoneOffset.UTC).toLocalDateTime())
         }
@@ -22,7 +23,7 @@ fun MysqlTypeMappings(): JdbcTypeMappings {
         }
     })
 
-    result.register(JsonData::class, object : JdbcMappedType<JsonData> {
+    result.register(typeOf<JsonData>(), object : JdbcMappedType<JsonData> {
         override fun writeJdbc(stmt: PreparedStatement, index: Int, value: JsonData) {
             stmt.setString(index, value.asString)
         }

--- a/postgres/src/main/kotlin/io/koalaql/postgres/PostgresDialect.kt
+++ b/postgres/src/main/kotlin/io/koalaql/postgres/PostgresDialect.kt
@@ -14,7 +14,7 @@ import io.koalaql.query.built.*
 import io.koalaql.sql.*
 import io.koalaql.window.*
 import io.koalaql.window.built.BuiltWindow
-import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 private fun UnmappedDataType<*>.toRawSql(): String = when (this) {
     DOUBLE -> "DOUBLE PRECISION"
@@ -138,11 +138,10 @@ class PostgresDialect: SqlDialect {
         val def = column.builtDef
 
         def.default?.let { default ->
-            @Suppress("unchecked_cast")
             val finalExpr = when (default) {
                 is ColumnDefaultExpr -> default.expr
                 is ColumnDefaultValue -> Literal(
-                    def.columnType.type as KClass<Any>,
+                    def.columnType.type,
                     default.value
                 )
             }

--- a/postgres/src/main/kotlin/io/koalaql/postgres/PostgresTypeMappings.kt
+++ b/postgres/src/main/kotlin/io/koalaql/postgres/PostgresTypeMappings.kt
@@ -7,11 +7,12 @@ import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.Timestamp
 import java.time.Instant
+import kotlin.reflect.typeOf
 
 fun PostgresTypeMappings(): JdbcTypeMappings {
     val result = JdbcTypeMappings()
 
-    result.register(Instant::class, object : JdbcMappedType<Instant> {
+    result.register(typeOf<Instant>(), object : JdbcMappedType<Instant> {
         override fun writeJdbc(stmt: PreparedStatement, index: Int, value: Instant) {
             stmt.setTimestamp(index, Timestamp.from(value))
         }
@@ -21,7 +22,7 @@ fun PostgresTypeMappings(): JdbcTypeMappings {
         }
     })
 
-    result.register(JsonData::class, object : JdbcMappedType<JsonData> {
+    result.register(typeOf<JsonData>(), object : JdbcMappedType<JsonData> {
         override fun writeJdbc(stmt: PreparedStatement, index: Int, value: JsonData) {
             stmt.setObject(index, value.asString, java.sql.Types.OTHER)
         }

--- a/postgres/src/main/kotlin/io/koalaql/postgres/SqlEscapes.kt
+++ b/postgres/src/main/kotlin/io/koalaql/postgres/SqlEscapes.kt
@@ -4,6 +4,7 @@ import io.koalaql.expr.Literal
 import io.koalaql.identifier.Named
 import io.koalaql.sql.SqlEscapes
 import org.postgresql.core.Utils
+import kotlin.reflect.typeOf
 
 object PostgresDdlEscapes: SqlEscapes {
     override fun identifier(sql: StringBuilder, identifier: Named) {
@@ -17,13 +18,13 @@ object PostgresDdlEscapes: SqlEscapes {
         }
 
         when (literal.type) {
-            Byte::class -> sql.append("${literal.value as Byte}")
-            Short::class -> sql.append("${literal.value as Short}")
-            Int::class -> sql.append("${literal.value as Int}")
-            Long::class -> sql.append("${literal.value as Long}")
-            Float::class -> sql.append("${literal.value as Float}")
-            Double::class -> sql.append("${literal.value as Double}")
-            String::class -> {
+            typeOf<Byte>() -> sql.append("${literal.value as Byte}")
+            typeOf<Short>() -> sql.append("${literal.value as Short}")
+            typeOf<Int>() -> sql.append("${literal.value as Int}")
+            typeOf<Long>() -> sql.append("${literal.value as Long}")
+            typeOf<Float>() -> sql.append("${literal.value as Float}")
+            typeOf<Double>() -> sql.append("${literal.value as Double}")
+            typeOf<String>() -> {
                 sql.append("'")
                 Utils.escapeLiteral(sql, literal.value as String, true)
                 sql.append("'")

--- a/postgres/src/main/kotlin/io/koalaql/postgres/SqlEscapes.kt
+++ b/postgres/src/main/kotlin/io/koalaql/postgres/SqlEscapes.kt
@@ -28,7 +28,7 @@ object PostgresDdlEscapes: SqlEscapes {
                 Utils.escapeLiteral(sql, literal.value as String, true)
                 sql.append("'")
             }
-            else -> error("${literal.type.simpleName} literals are not supported in Postgres DDL")
+            else -> error("${literal.type} literals are not supported in Postgres DDL")
         }
     }
 }

--- a/testing/src/test/kotlin/DataTypesTest.kt
+++ b/testing/src/test/kotlin/DataTypesTest.kt
@@ -36,7 +36,7 @@ abstract class DataTypesTest : ProvideTestDatabase {
     }
 
     private fun <T : Any> selectData(cxn: DataConnection, values: DataTypeWithValues<T>) {
-        val label = Label(values.type.type, Unnamed())
+        val label = Label<T>(values.type.type, Unnamed())
         val casted = cast(cast(label, values.type), values.type)
 
         val rows = values(values.values) { this[label] = it }
@@ -139,7 +139,7 @@ abstract class DataTypesTest : ProvideTestDatabase {
     @Test
     fun `read and write null`() = withCxn { cxn ->
         examples().entries().forEach {
-            val name = Label(it.type.type, Unnamed())
+            val name = Label<Any>(it.type.type, Unnamed())
             val wasNull = name.isNull() as_ label()
 
             val row = values(listOf(1)) { this[name] = null }


### PR DESCRIPTION
This PR will explore using KType instead of KClass for type tokens. This will allow type mappings to support concrete generic types. Additionally, I'll aim to eliminate the `kotlin("reflect")` dependency.