### PR TITLE
Fix overload resolution ambiguity on setTo(null)

### DIFF
--- a/core/src/main/kotlin/io/koalaql/dsl/Exprs.kt
+++ b/core/src/main/kotlin/io/koalaql/dsl/Exprs.kt
@@ -169,6 +169,9 @@ infix fun Expr<String>.notLike(expr: String) = notLike(value(expr))
 fun <T : Any> rawExpr(build: RawSqlBuilder.() -> Unit): Expr<T> =
     RawExpr(build)
 
+infix fun <T : Any> Reference<T>.setTo(rhs: Nothing?): Assignment<T> =
+    ExprAssignment(this, null_())
+
 infix fun <T : Any> Reference<T>.setTo(rhs: Expr<T>?): Assignment<T> =
     ExprAssignment(this, rhs ?: null_())
 

--- a/testing/src/test/kotlin/QueryTests.kt
+++ b/testing/src/test/kotlin/QueryTests.kt
@@ -1,4 +1,5 @@
 import io.koalaql.DataConnection
+import io.koalaql.Isolation
 import io.koalaql.ddl.*
 import io.koalaql.dsl.*
 import io.koalaql.expr.Reference
@@ -1208,5 +1209,25 @@ abstract class QueryTests: ProvideTestDatabase {
 
         assertEquals(data1.normalized, x.normalized)
         assertEquals(data1.normalized, y.normalized)
+    }
+
+    @Test
+    fun `support setting value to null`() = withDb { db ->
+        db.connect(Isolation.READ_COMMITTED).use { cxn ->
+            cxn.jdbc.prepareStatement("""
+                CREATE TABLE IF NOT EXISTS "Example"(
+                    "id" INTEGER NOT NULL,
+                    "nullable" VARCHAR(100)
+                )
+            """.trimIndent()).execute()
+            cxn.jdbc.commit()
+        }
+
+        val myTable = object : Table("Example") {
+            val id = column("id", INTEGER.primaryKey())
+`            val nullable = column("nullable", VARCHAR(100).nullable())
+        }
+
+        myTable.insert(rowOf(myTable.id setTo 1, myTable.nullable setTo null)).perform(db)
     }
 }

--- a/testing/src/test/kotlin/QueryTests.kt
+++ b/testing/src/test/kotlin/QueryTests.kt
@@ -1211,23 +1211,18 @@ abstract class QueryTests: ProvideTestDatabase {
         assertEquals(data1.normalized, y.normalized)
     }
 
+    object SettingNullTable : Table("Example") {
+        val id = column("id", INTEGER.primaryKey())
+        val nullable = column("nullable", VARCHAR(100).nullable())
+    }
+
     @Test
-    fun `support setting value to null`() = withDb { db ->
-        db.connect(Isolation.READ_COMMITTED).use { cxn ->
-            cxn.jdbc.prepareStatement("""
-                CREATE TABLE IF NOT EXISTS "Example"(
-                    "id" INTEGER NOT NULL,
-                    "nullable" VARCHAR(100)
-                )
-            """.trimIndent()).execute()
-            cxn.jdbc.commit()
-        }
-
-        val myTable = object : Table("Example") {
-            val id = column("id", INTEGER.primaryKey())
-            val nullable = column("nullable", VARCHAR(100).nullable())
-        }
-
-        myTable.insert(rowOf(myTable.id setTo 1, myTable.nullable setTo null)).perform(db)
+    fun `support setting value to null`() = withCxn(SettingNullTable) { cxn ->
+        SettingNullTable
+            .insert(rowOf(
+                SettingNullTable.id setTo 1,
+                SettingNullTable.nullable setTo null
+            ))
+            .perform(cxn)
     }
 }

--- a/testing/src/test/kotlin/QueryTests.kt
+++ b/testing/src/test/kotlin/QueryTests.kt
@@ -1225,7 +1225,7 @@ abstract class QueryTests: ProvideTestDatabase {
 
         val myTable = object : Table("Example") {
             val id = column("id", INTEGER.primaryKey())
-`            val nullable = column("nullable", VARCHAR(100).nullable())
+            val nullable = column("nullable", VARCHAR(100).nullable())
         }
 
         myTable.insert(rowOf(myTable.id setTo 1, myTable.nullable setTo null)).perform(db)


### PR DESCRIPTION
Both overloads of `Reference<T>.setTo` take nullable parameters, so setTo(null) is ambiguous. We add an overload of

```kotlin
setTo(rhs: Nothing?)
```

To disambiguate 