### PR TITLE
fix: upgrade gradle → `8.1.1`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,5 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.parallel.intra=true
 org.gradle.configureondemand=true
-org.gradle.configuration-cache=true
+org.gradle.configuration-cache=false
 org.gradle.configuration-cache.problems=warn

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fixes build caching with the new Buildless plugin, due to elide-dev/buildless#13.