### PR TITLE
Extended Postgres ON CONFLICT support

### DIFF
--- a/core/src/main/kotlin/io/koalaql/query/OnConflictAction.kt
+++ b/core/src/main/kotlin/io/koalaql/query/OnConflictAction.kt
@@ -6,15 +6,15 @@ import io.koalaql.ddl.built.BuiltNamedIndex
 sealed interface OnConflictOrDuplicateAction
 
 sealed interface OnConflictAction: OnConflictOrDuplicateAction {
-    val key: BuiltNamedIndex
+    val key: OnConflictKey
 }
 
 class OnConflictIgnore(
-    override val key: BuiltNamedIndex
+    override val key: OnConflictKey
 ): OnConflictAction
 
 class OnConflictUpdate(
-    override val key: BuiltNamedIndex,
+    override val key: OnConflictKey,
     val assignments: List<Assignment<*>>
 ): OnConflictAction
 

--- a/core/src/main/kotlin/io/koalaql/query/OnConflictKey.kt
+++ b/core/src/main/kotlin/io/koalaql/query/OnConflictKey.kt
@@ -1,0 +1,14 @@
+package io.koalaql.query
+
+import io.koalaql.ddl.TableColumn
+import io.koalaql.ddl.built.BuiltNamedIndex
+
+sealed interface OnConflictKey
+
+data class OnConflictKeyIndex(
+    val index: BuiltNamedIndex
+): OnConflictKey
+
+data class OnConflictKeyColumns(
+    val columns: List<TableColumn<*>>
+): OnConflictKey

--- a/core/src/main/kotlin/io/koalaql/query/OnConflictKey.kt
+++ b/core/src/main/kotlin/io/koalaql/query/OnConflictKey.kt
@@ -2,6 +2,7 @@ package io.koalaql.query
 
 import io.koalaql.ddl.TableColumn
 import io.koalaql.ddl.built.BuiltNamedIndex
+import io.koalaql.expr.Expr
 
 sealed interface OnConflictKey
 
@@ -10,5 +11,6 @@ data class OnConflictKeyIndex(
 ): OnConflictKey
 
 data class OnConflictKeyColumns(
-    val columns: List<TableColumn<*>>
+    val columns: List<TableColumn<*>>,
+    val where: Expr<Boolean>?
 ): OnConflictKey

--- a/core/src/main/kotlin/io/koalaql/query/fluent/OnConflictable.kt
+++ b/core/src/main/kotlin/io/koalaql/query/fluent/OnConflictable.kt
@@ -3,6 +3,7 @@ package io.koalaql.query.fluent
 import io.koalaql.Assignment
 import io.koalaql.ddl.TableColumn
 import io.koalaql.ddl.built.BuiltNamedIndex
+import io.koalaql.expr.Expr
 import io.koalaql.query.*
 import io.koalaql.query.built.BuiltInsert
 import io.koalaql.query.built.InsertBuilder
@@ -18,21 +19,47 @@ interface OnConflictable: GeneratingKeys {
         }
     }
 
-    private fun onConflict(key: OnConflictKey): OnConflicted {
-        return object : OnConflicted {
+    private fun onConflict(key: OnConflictKey): OnConflictedWhereable {
+        return object : OnConflictedWhereable {
             override fun ignore(): GeneratingKeys =
                 OnConflict(this@OnConflictable, OnConflictIgnore(key))
 
             override fun update(assignments: List<Assignment<*>>): GeneratingKeys =
                 OnConflict(this@OnConflictable, OnConflictUpdate(key, assignments))
+
+            override fun where(where: Expr<Boolean>) = object : OnConflicted {
+                override fun ignore(): GeneratingKeys =
+                    OnConflict(this@OnConflictable, OnConflictIgnore(key))
+
+                override fun update(assignments: List<Assignment<*>>): GeneratingKeys =
+                    OnConflict(this@OnConflictable, OnConflictUpdate(key, assignments))
+            }
         }
     }
+    
+    private fun onConflict(
+        key: () -> OnConflictKey
+    ): OnConflicted = object : OnConflicted {
+        override fun ignore(): GeneratingKeys =
+            OnConflict(this@OnConflictable, OnConflictIgnore(key()))
 
-    fun onConflict(index: BuiltNamedIndex): OnConflicted =
-        onConflict(OnConflictKeyIndex(index))
+        override fun update(assignments: List<Assignment<*>>): GeneratingKeys =
+            OnConflict(this@OnConflictable, OnConflictUpdate(key(), assignments))
+    }
+    
+    fun onConflict(index: BuiltNamedIndex): OnConflicted = onConflict { 
+        OnConflictKeyIndex(index)
+    }
 
-    fun onConflict(vararg columns: TableColumn<*>): OnConflicted =
-        onConflict(OnConflictKeyColumns(columns.asList()))
+    fun onConflict(vararg columns: TableColumn<*>): OnConflictedWhereable {
+        return object : OnConflictedWhereable, OnConflicted by onConflict({
+            OnConflictKeyColumns(columns.asList(), null)
+        }) {
+            override fun where(where: Expr<Boolean>) = onConflict {
+                OnConflictKeyColumns(columns.asList(), where)
+            }
+        }
+    }
 
     fun onDuplicate(): OnDuplicated = object : OnDuplicated {
         override fun update(assignments: List<Assignment<*>>): GeneratingKeys =

--- a/core/src/main/kotlin/io/koalaql/query/fluent/OnConflictable.kt
+++ b/core/src/main/kotlin/io/koalaql/query/fluent/OnConflictable.kt
@@ -1,11 +1,9 @@
 package io.koalaql.query.fluent
 
 import io.koalaql.Assignment
+import io.koalaql.ddl.TableColumn
 import io.koalaql.ddl.built.BuiltNamedIndex
-import io.koalaql.query.OnConflictIgnore
-import io.koalaql.query.OnConflictOrDuplicateAction
-import io.koalaql.query.OnConflictUpdate
-import io.koalaql.query.OnDuplicateUpdate
+import io.koalaql.query.*
 import io.koalaql.query.built.BuiltInsert
 import io.koalaql.query.built.InsertBuilder
 
@@ -20,15 +18,21 @@ interface OnConflictable: GeneratingKeys {
         }
     }
 
-    fun onConflict(keys: BuiltNamedIndex): OnConflicted {
+    private fun onConflict(key: OnConflictKey): OnConflicted {
         return object : OnConflicted {
             override fun ignore(): GeneratingKeys =
-                OnConflict(this@OnConflictable, OnConflictIgnore(keys))
+                OnConflict(this@OnConflictable, OnConflictIgnore(key))
 
             override fun update(assignments: List<Assignment<*>>): GeneratingKeys =
-                OnConflict(this@OnConflictable, OnConflictUpdate(keys, assignments))
+                OnConflict(this@OnConflictable, OnConflictUpdate(key, assignments))
         }
     }
+
+    fun onConflict(index: BuiltNamedIndex): OnConflicted =
+        onConflict(OnConflictKeyIndex(index))
+
+    fun onConflict(vararg columns: TableColumn<*>): OnConflicted =
+        onConflict(OnConflictKeyColumns(columns.asList()))
 
     fun onDuplicate(): OnDuplicated = object : OnDuplicated {
         override fun update(assignments: List<Assignment<*>>): GeneratingKeys =

--- a/core/src/main/kotlin/io/koalaql/query/fluent/OnConflictedWhereable.kt
+++ b/core/src/main/kotlin/io/koalaql/query/fluent/OnConflictedWhereable.kt
@@ -1,0 +1,7 @@
+package io.koalaql.query.fluent
+
+import io.koalaql.expr.Expr
+
+interface OnConflictedWhereable: OnConflicted {
+    fun where(where: Expr<Boolean>): OnConflicted
+}

--- a/core/src/main/kotlin/io/koalaql/sql/ScopedSqlBuilder.kt
+++ b/core/src/main/kotlin/io/koalaql/sql/ScopedSqlBuilder.kt
@@ -456,6 +456,11 @@ class ScopedSqlBuilder(
                         compileExpr(it)
                     }
                 }
+
+                key.where?.let {
+                    addSql("\nWHERE ")
+                    compileExpr(it)
+                }
             }
         }
     }

--- a/core/src/main/kotlin/io/koalaql/sql/ScopedSqlBuilder.kt
+++ b/core/src/main/kotlin/io/koalaql/sql/ScopedSqlBuilder.kt
@@ -440,21 +440,39 @@ class ScopedSqlBuilder(
         addTableName(table.tableName)
     }
 
+    private fun compileOnConflictKey(
+        key: OnConflictKey,
+        compileExpr: (Expr<*>) -> Unit
+    ) {
+        when (key) {
+            is OnConflictKeyIndex -> {
+                addSql("\nON CONFLICT ON CONSTRAINT ")
+                addIdentifier(key.index.name)
+            }
+            is OnConflictKeyColumns -> {
+                addSql("\nON CONFLICT ")
+                parenthesize {
+                    prefix("", ", ").forEach(key.columns) {
+                        compileExpr(it)
+                    }
+                }
+            }
+        }
+    }
+
     fun compileOnConflict(
         onConflict: OnConflictOrDuplicateAction?,
-        compileAssignment: (Assignment<*>) -> Unit
+        compileAssignment: (Assignment<*>) -> Unit,
+        compileExpr: (Expr<*>) -> Unit
     ) {
         val assignments = when (onConflict) {
             is OnConflictIgnore -> {
-                addSql("\nON CONFLICT ON CONSTRAINT ")
-                addIdentifier(onConflict.key.name)
+                compileOnConflictKey(onConflict.key, compileExpr)
                 addSql(" DO NOTHING")
                 return
             }
             is OnConflictUpdate -> {
-                addSql("\nON CONFLICT ON CONSTRAINT ")
-                addIdentifier(onConflict.key.name)
-
+                compileOnConflictKey(onConflict.key, compileExpr)
                 addSql(" DO UPDATE SET")
 
                 onConflict.assignments

--- a/h2/src/main/kotlin/io/koalaql/h2/H2Dialect.kt
+++ b/h2/src/main/kotlin/io/koalaql/h2/H2Dialect.kt
@@ -338,9 +338,10 @@ class H2Dialect(
 
             val sql = withColumns(relvar.columns)
 
-            sql.compileOnConflict(it) {
-                sql.compileAssignment(it)
-            }
+            sql.compileOnConflict(it,
+                compileAssignment = { sql.compileAssignment(it) },
+                compileExpr = { sql.compileExpr(it, false) }
+            )
         }
     )
 

--- a/h2/src/main/kotlin/io/koalaql/h2/H2Dialect.kt
+++ b/h2/src/main/kotlin/io/koalaql/h2/H2Dialect.kt
@@ -84,7 +84,7 @@ class H2Dialect(
     }
 
     private fun ScopedSqlBuilder.compileExpr(expr: Expr<*>, emitParens: Boolean) {
-        compiler.compileExpr(this, expr, emitParens)
+        compiler.compileExpr(this, expr, emitParens, true)
     }
 
     private fun ScopedSqlBuilder.compileDefaultExpr(expr: Expr<*>) {

--- a/mysql/src/main/kotlin/io/koalaql/mysql/MysqlDialect.kt
+++ b/mysql/src/main/kotlin/io/koalaql/mysql/MysqlDialect.kt
@@ -49,7 +49,12 @@ class MysqlDialect: SqlDialect {
             }
         }
 
-        override fun compileExpr(builder: ScopedSqlBuilder, expr: QuasiExpr, emitParens: Boolean) {
+        override fun compileExpr(
+            builder: ScopedSqlBuilder,
+            expr: QuasiExpr,
+            emitParens: Boolean,
+            emitAliases: Boolean
+        ) {
             when {
                 expr is OperationExpr<*> && expr.type == StandardOperationType.CURRENT_TIMESTAMP -> {
                     check(expr.args.isEmpty())
@@ -58,7 +63,7 @@ class MysqlDialect: SqlDialect {
                         builder.addSql("UTC_TIMESTAMP")
                     }
                 }
-                else -> super.compileExpr(builder, expr, emitParens)
+                else -> super.compileExpr(builder, expr, emitParens, emitAliases)
             }
         }
     }
@@ -296,7 +301,7 @@ class MysqlDialect: SqlDialect {
                     addSql("UTC_TIMESTAMP")
                 }
             }*/
-            else -> compiler.compileExpr(this, expr, emitParens)
+            else -> compiler.compileExpr(this, expr, emitParens, true)
         }
     }
 

--- a/mysql/src/main/kotlin/io/koalaql/mysql/MysqlDialect.kt
+++ b/mysql/src/main/kotlin/io/koalaql/mysql/MysqlDialect.kt
@@ -478,9 +478,14 @@ class MysqlDialect: SqlDialect {
 
             val sql = withColumns(relvar.columns, alias(relvar.tableName.name))
 
-            sql.compileOnConflict(it) {
-                sql.compileAssignment(it)
-            }
+            sql.compileOnConflict(it,
+                compileAssignment = { assignment ->
+                    sql.compileAssignment(assignment)
+                },
+                compileExpr = { expr ->
+                    sql.compileExpr(expr, false)
+                }
+            )
         }
     )
 

--- a/postgres/src/main/kotlin/io/koalaql/postgres/PostgresDialect.kt
+++ b/postgres/src/main/kotlin/io/koalaql/postgres/PostgresDialect.kt
@@ -53,7 +53,12 @@ class PostgresDialect: SqlDialect {
             builder.compileWindow(window)
         }
 
-        override fun compileExpr(builder: ScopedSqlBuilder, expr: QuasiExpr, emitParens: Boolean) {
+        override fun compileExpr(
+            builder: ScopedSqlBuilder,
+            expr: QuasiExpr,
+            emitParens: Boolean,
+            emitAliases: Boolean
+        ) {
             when {
                 expr is OperationExpr<*> && expr.type == StandardOperationType.CURRENT_TIMESTAMP -> {
                     check(expr.args.isEmpty())
@@ -62,7 +67,7 @@ class PostgresDialect: SqlDialect {
                         builder.addSql("NOW()")
                     }
                 }
-                else -> super.compileExpr(builder, expr, emitParens)
+                else -> super.compileExpr(builder, expr, emitParens, emitAliases)
             }
         }
     }
@@ -423,8 +428,17 @@ class PostgresDialect: SqlDialect {
         resolveWithoutAlias(expr)
     }
 
-    fun ScopedSqlBuilder.compileExpr(expr: QuasiExpr, emitParens: Boolean = true) {
-        compiler.compileExpr(this, expr, emitParens)
+    fun ScopedSqlBuilder.compileExpr(
+        expr: QuasiExpr,
+        emitParens: Boolean = true,
+        emitAliases: Boolean = true,
+    ) {
+        compiler.compileExpr(
+            this,
+            expr,
+            emitParens,
+            emitAliases
+        )
     }
 
     fun ScopedSqlBuilder.compileRelation(relation: BuiltRelation) {
@@ -527,7 +541,10 @@ class PostgresDialect: SqlDialect {
                 builder.compileAssignment(assignment)
             },
             compileExpr = { expr ->
-                builder.compileExpr(expr, false)
+                builder.compileExpr(expr,
+                    emitParens = false,
+                    emitAliases = false
+                )
             }
         )
 

--- a/postgres/src/main/kotlin/io/koalaql/postgres/PostgresDialect.kt
+++ b/postgres/src/main/kotlin/io/koalaql/postgres/PostgresDialect.kt
@@ -521,9 +521,15 @@ class PostgresDialect: SqlDialect {
 
         val builder = withColumns(relvar.columns, insertAlias)
 
-        compileOnConflict(insert.onConflict) { assignment ->
-            builder.compileAssignment(assignment)
-        }
+        compileOnConflict(
+            insert.onConflict,
+            compileAssignment = { assignment ->
+                builder.compileAssignment(assignment)
+            },
+            compileExpr = { expr ->
+                builder.compileExpr(expr, false)
+            }
+        )
 
         return nonEmpty
     }

--- a/postgres/src/test/kotlin/PostgresQueryTests.kt
+++ b/postgres/src/test/kotlin/PostgresQueryTests.kt
@@ -1,15 +1,15 @@
 import io.koalaql.Isolation
+import io.koalaql.ddl.INTEGER
 import io.koalaql.ddl.Table
 import io.koalaql.ddl.VARCHAR
-import io.koalaql.dsl.iLike
-import io.koalaql.dsl.rowOf
-import io.koalaql.dsl.setTo
-import io.koalaql.dsl.value
+import io.koalaql.dsl.*
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import io.koalaql.expr.Expr
 import io.koalaql.expr.ExtendedOperationType
 import io.koalaql.expr.OperationFixity
+import io.koalaql.postgres.generatePostgresSql
+import kotlin.test.assertEquals
 
 class PostgresQueryTests: QueryTests(), PostgresTestProvider {
     override val requiresOnConflictKey get() = true
@@ -50,8 +50,57 @@ class PostgresQueryTests: QueryTests(), PostgresTestProvider {
     @Test
     fun `custom ilike operator`() = iLikeTest { x, y -> customIlikeOp(x, value(y)) }
 
-    @Test
-    fun `on conflict where`() = withDb { db ->
+    private object OnConflictTable: Table("OnConflictWhere") {
+        val column1 = column("column_1", INTEGER)
+        val column2 = column("column_2", INTEGER)
 
+        val c1c2 = uniqueKey(column1, column2)
+    }
+
+    @Test
+    fun `on conflict where`() = withCxn(OnConflictTable) { cxn ->
+        val baseInsert = OnConflictTable
+            .insert(rowOf(
+                OnConflictTable.column1 setTo 1,
+                OnConflictTable.column2 setTo 2
+            ))
+
+        val indexCase = baseInsert
+            .onConflict(OnConflictTable.c1c2)
+            .ignore()
+            .apply { perform(cxn) }
+            .generatePostgresSql()
+
+        val doubleColumn = baseInsert
+            .onConflict(OnConflictTable.column1, OnConflictTable.column2)
+            .ignore()
+            .apply { perform(cxn) }
+            .generatePostgresSql()
+
+        val withWhere = baseInsert
+            .onConflict(OnConflictTable.column1, OnConflictTable.column2)
+            .where(OnConflictTable.column2 greater 0)
+            .ignore()
+            .apply { perform(cxn) }
+            .generatePostgresSql()
+
+        assertEquals("""
+            INSERT INTO "OnConflictWhere" AS T0("column_1", "column_2")
+            VALUES (?, ?)
+            ON CONFLICT ON CONSTRAINT "OnConflictWhere_column_1_column_2_key" DO NOTHING
+        """.trimIndent(), indexCase?.parameterizedSql)
+
+        assertEquals("""
+            INSERT INTO "OnConflictWhere" AS T0("column_1", "column_2")
+            VALUES (?, ?)
+            ON CONFLICT ("column_1", "column_2") DO NOTHING
+        """.trimIndent(), doubleColumn?.parameterizedSql)
+
+        assertEquals("""
+            INSERT INTO "OnConflictWhere" AS T0("column_1", "column_2")
+            VALUES (?, ?)
+            ON CONFLICT ("column_1", "column_2")
+            WHERE "column_2" > ? DO NOTHING
+        """.trimIndent(), withWhere?.parameterizedSql)
     }
 }

--- a/postgres/src/test/kotlin/PostgresQueryTests.kt
+++ b/postgres/src/test/kotlin/PostgresQueryTests.kt
@@ -49,4 +49,9 @@ class PostgresQueryTests: QueryTests(), PostgresTestProvider {
 
     @Test
     fun `custom ilike operator`() = iLikeTest { x, y -> customIlikeOp(x, value(y)) }
+
+    @Test
+    fun `on conflict where`() = withDb { db ->
+
+    }
 }


### PR DESCRIPTION
Closes #41

1. Support named columns in `.onConflict` clauses
2. Support `.where` clause on `.onConflict` with named columns