### PR TITLE
chore: update `buildless` plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,10 +4,8 @@ pluginManagement {
   }
 }
 
-import build.less.plugin.settings.buildless
-
 plugins {
-  id("build.less") version("1.0.0-beta1")
+  id("build.less") version("1.0.0-beta8")
   id("com.gradle.enterprise") version("3.13")
   id("org.gradle.toolchains.foojay-resolver-convention") version("0.5.0")
 }
@@ -26,7 +24,3 @@ include("h2")
 include("mysql")
 include("postgres")
 include("docs")
-
-buildless {
-  // the sweet sound of silence
-}


### PR DESCRIPTION
## Summary

Many updates and fixes in the Buildless plugin have landed. There is no need for an extension call or import now. More coming soon, including formal support for the Buildless Agent within Github Actions.

Cheers 🦘
