### PR TITLE
fix: runner hardener network blocking

### DIFF
--- a/.github/workflows/check.codeql.yml
+++ b/.github/workflows/check.codeql.yml
@@ -38,23 +38,7 @@ jobs:
         uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
         with:
           disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            agent.less.build:443
-            cli.less.build:443
-            dl.less.build:443
-            edge.pkg.st:443
-            maven.pkg.st:443
-            github.com:443
-            global.less.build:443
-            gradle.pkg.st:443
-            jcenter.bintray.com:443
-            local.less.build:443
-            plugins-artifacts.gradle.org:443
-            plugins.gradle.org:443
-            repo.maven.apache.org:443
-            scans-in.gradle.com:443
-            api.github.com:443
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@v4
       - name: Configure JDK

--- a/.github/workflows/check.deps.yml
+++ b/.github/workflows/check.deps.yml
@@ -21,10 +21,7 @@ jobs:
         uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
         with:
           disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            github.com:443
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@v4
       - name: Check Dependencies


### PR DESCRIPTION
## Summary

It shouldn't be blocking CodeQL, but it is, so it gets the delete stick. If you rebase the Dependabot PRs after merging, they should pass.
